### PR TITLE
feature: add documentation link to footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -29,6 +29,7 @@ function Footer() {
         <Link to="/carousel">Carousel</Link>
         <Link to="/modal">Modal</Link>
         <Link to="/scroll">Scroll</Link>
+        <Link to="https://docs.react-joyride.com/" target="__blank">Documentation</Link>
       </Spacer>
       <Box height={32} width={32} />
     </Box>


### PR DESCRIPTION
With regards to this discussion: https://github.com/gilbarbara/react-joyride/discussions/967

This addition makes it easier to find the documentation from within the demo.

![image](https://github.com/user-attachments/assets/e32796b9-2a57-47e6-8746-94fac24e80f7)
